### PR TITLE
Immer korrekte PHP tags verwenden

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1,4 +1,4 @@
-<?
+<?php
 $oBeMails = new nvBeMails;
 
 $addon = rex_addon::get("nv_bemails");


### PR DESCRIPTION
die short tags sind auf vielen Systemen deaktiviert.